### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/ch/unibas/medizin/depot/service/DepotService.java
+++ b/src/main/java/ch/unibas/medizin/depot/service/DepotService.java
@@ -86,7 +86,14 @@ public record DepotService(
     public Resource get(final String file) {
         final var normalizedFile = DepotUtil.normalizePath(file);
         final var tokenData = getTokenData();
-        final var fullPath = tokenData.basePath().resolve(normalizedFile);
+        final var fullPath = tokenData.basePath().resolve(normalizedFile).normalize().toAbsolutePath();
+        final var basePath = tokenData.basePath().normalize().toAbsolutePath();
+
+        // Ensure fullPath is still contained in basePath
+        if (!fullPath.startsWith(basePath)) {
+            log.info("Requested path {} is outside of base directory {}", fullPath, basePath);
+            throw new FileNotFoundException(file); // or use a dedicated exception
+        }
 
         logService.log(tokenData.tenant, LogService.EventType.GET, tokenData.subject(), fullPath.toString());
         log.info("{} get {}", tokenData.subject(), fullPath);


### PR DESCRIPTION
Potential fix for [https://github.com/unibas-medfak/depot/security/code-scanning/6](https://github.com/unibas-medfak/depot/security/code-scanning/6)

To eliminate the vulnerability, after resolving and normalizing the file path (combining the user's input and the base directory), check that the resulting path is still contained within the expected base directory. This is done by normalizing both the base directory and resolved file path to their absolute forms, then using `Path.startsWith(basePath)` to confirm containment. If the check fails, throw an exception to prevent any file access outside the sandbox. The patch should be applied in `DepotService.java` within the `get` method: after computing `fullPath`, add logic that ensures `fullPath` is contained within `tokenData.basePath()` (proper normalization and absolute path required). If the check fails, throw a relevant exception.

This logic does not affect existing functionality except in cases where a user attempts to access files/folders outside their sandbox/root path. No new helper method is needed beyond the standard Java NIO API; imports are already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
