### PR TITLE
Use Path.startsWith for tenant containment check in put()

### DIFF
--- a/src/main/java/ch/unibas/medizin/depot/service/DepotService.java
+++ b/src/main/java/ch/unibas/medizin/depot/service/DepotService.java
@@ -24,7 +24,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.io.File;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
@@ -128,7 +127,7 @@ public record DepotService(
         final var fullPathAndFile = fullPath.resolve(Objects.requireNonNull(file.getOriginalFilename())).normalize().toAbsolutePath();
 
         // Ensure the resolved file stays within the tenant/base path
-        if (!fullPathAndFile.startsWith(fullPath + File.separator)) {
+        if (!fullPathAndFile.startsWith(fullPath)) {
             log.error("Attempt to store file outside permitted path: {}", fullPathAndFile);
             throw new IllegalArgumentException("Invalid file path");
         }

--- a/src/test/java/ch/unibas/medizin/depot/service/DepotServiceTests.java
+++ b/src/test/java/ch/unibas/medizin/depot/service/DepotServiceTests.java
@@ -11,6 +11,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 import java.util.Arrays;
 import java.util.concurrent.Executors;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 @SpringBootTest
 public class DepotServiceTests {
 
@@ -35,6 +37,14 @@ public class DepotServiceTests {
                 executor.execute(() -> depotService.put(mockFile, "/concurrent/test/", true));
             }
         }
+    }
+
+    @Test
+    @WithMockUser(username = "tenant" + Character.LINE_SEPARATOR + "realm" + Character.LINE_SEPARATOR + "subject")
+    public void Put_rejects_parent_directory_traversal_in_filename() {
+        var mockFile = new MockMultipartFile("file", "../../../evil.txt", "text/plain", "x".getBytes());
+        assertThrows(IllegalArgumentException.class,
+                () -> depotService.put(mockFile, "/traversal/", false));
     }
 
 }


### PR DESCRIPTION
## Summary
- Mirror the pattern already used in `DepotService.get()`: compare normalized `Path`s element-wise instead of concatenating `File.separator` to the string form.
- Add a regression test confirming that `../../../evil.txt` as a filename is rejected with `IllegalArgumentException`.

## Context
This is a small consistency cleanup motivated by the discussion on #207. The prior `fullPathAndFile.startsWith(fullPath + File.separator)` check was already effective after `.normalize().toAbsolutePath()` on both sides; switching to `Path.startsWith(Path)` just removes the string-concat detour and uses the element-wise comparison (so a sibling directory whose name shares a prefix can't ever spuriously match).

No behavior change for valid inputs. The regression test locks in that a real `../` escape in the multipart filename is rejected at the service layer, independent of the controller-level filename validation in `ApiController`/`DepotUtil.isValidFilename`.

## Test plan
- [x] `./mvnw -Dtest=DepotServiceTests#Put_rejects_parent_directory_traversal_in_filename test` passes
- [x] Server log shows `Attempt to store file outside permitted path: /tmp/depot/evil.txt` (the containment check is the line that throws)
- [ ] Full test suite in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)